### PR TITLE
APIGOV-00000 - change name of release action

### DIFF
--- a/.github/workflows/apigee-agents-release.yml
+++ b/.github/workflows/apigee-agents-release.yml
@@ -1,4 +1,4 @@
-name: Build Apigee discovery agent
+name: Release Apigee Agents
 
 on:
   push:


### PR DESCRIPTION
Change the name of the GitHub action from "Build Apigee discovery agent" to "Release Apigee Agents" to more properly describe the action.