### PR TITLE
APIGOV-23935 - product discovery mode

### DIFF
--- a/client/pkg/apigee/apicalls.go
+++ b/client/pkg/apigee/apicalls.go
@@ -116,18 +116,21 @@ func (a *ApigeeClient) RemoveDeveloperApp(appName, developerID string) error {
 }
 
 // GetProducts - get the list of products for the org
-func (a *ApigeeClient) GetProducts() Products {
+func (a *ApigeeClient) GetProducts() (Products, error) {
 	// Get the products
 	response, err := a.newRequest(http.MethodGet, fmt.Sprintf("%s/apiproducts", a.orgURL),
 		WithDefaultHeaders(),
 	).Execute()
+	if err != nil {
+		return nil, err
+	}
 
 	products := Products{}
 	if err == nil {
 		json.Unmarshal(response.Body, &products)
 	}
 
-	return products
+	return products, nil
 }
 
 // GetProduct - get details of the product

--- a/client/pkg/apigee/specs.go
+++ b/client/pkg/apigee/specs.go
@@ -9,7 +9,7 @@ import (
 // GetSpecFile - downloads the specfile from apigee given the path of its location
 func (a *ApigeeClient) GetSpecFile(specPath string) ([]byte, error) {
 	// Get the spec file
-	response, err := a.newRequest(http.MethodGet, fmt.Sprintf("%s/%s", a.dataURL, specPath),
+	response, err := a.newRequest(http.MethodGet, fmt.Sprintf("%s%s", a.dataURL, specPath),
 		WithDefaultHeaders(),
 	).Execute()
 

--- a/client/pkg/config/config.go
+++ b/client/pkg/config/config.go
@@ -73,6 +73,7 @@ const (
 	pathAPIVersion         = "apigee.apiVersion"
 	pathOrganization       = "apigee.organization"
 	pathMode               = "apigee.discoveryMode"
+	pathFilter             = "apigee.filter"
 	pathAuthURL            = "apigee.auth.url"
 	pathAuthServerUsername = "apigee.auth.serverUsername"
 	pathAuthServerPassword = "apigee.auth.serverPassword"
@@ -93,8 +94,9 @@ func AddProperties(rootProps properties.Properties) {
 	rootProps.AddStringProperty(pathOrganization, "", "APIGEE Organization")
 	rootProps.AddStringProperty(pathURL, "https://api.enterprise.apigee.com", "APIGEE Base URL")
 	rootProps.AddStringProperty(pathAPIVersion, "v1", "APIGEE API Version")
+	rootProps.AddStringProperty(pathFilter, "", "Filter used on discovering Apigee products")
 	rootProps.AddStringProperty(pathDataURL, "https://apigee.com/dapi/api", "APIGEE Data API URL")
-	rootProps.AddStringProperty(pathAuthURL, "https://login.apigee.com", "URL to use when authenticting to APIGEE")
+	rootProps.AddStringProperty(pathAuthURL, "https://login.apigee.com", "URL to use when authenticating to APIGEE")
 	rootProps.AddStringProperty(pathAuthServerUsername, "edgecli", "Username to use to when requesting APIGEE token")
 	rootProps.AddStringProperty(pathAuthServerPassword, "edgeclisecret", "Password to use to when requesting APIGEE token")
 	rootProps.AddStringProperty(pathAuthUsername, "", "Username to use to authenticate to APIGEE")
@@ -117,6 +119,7 @@ func ParseConfig(rootProps properties.Properties) *ApigeeConfig {
 		DataURL:      strings.TrimSuffix(rootProps.StringPropertyValue(pathDataURL), "/"),
 		DeveloperID:  rootProps.StringPropertyValue(pathDeveloper),
 		mode:         stringToDiscoveryMode(rootProps.StringPropertyValue(pathMode)),
+		Filter:       rootProps.StringPropertyValue(pathFilter),
 		Intervals: &ApigeeIntervals{
 			Proxy:   rootProps.DurationPropertyValue(pathProxyInterval),
 			Spec:    rootProps.DurationPropertyValue(pathSpecInterval),

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -48,9 +48,15 @@ go build -tags static_all \
 ./apigee_discovery_agent.exe --envFile env_vars
 ```
 
-## Proxy discovery
+## Discovery Mode - Proxy
+
+This is the default operating mode that discoveries API Proxies and attempts to match them to Specs
+
+### Proxy discovery
 
 * Find all specs
+  * Parse all specs to determine endpoints with in
+  * Save info to cache
 * Find all Deployed API Proxies
   * Find the Spec
     * Proxy Revision has spec set, use it
@@ -63,7 +69,7 @@ go build -tags static_all \
     * If spec was not found create as unstructured  
     * Attach appropriate Credential Request Definition based on policy in proxy
 
-## Provisioning process
+### Proxy provisioning
 
 * Managed Application
   * Creates a new App on Apigee under the configured developer
@@ -73,9 +79,35 @@ go build -tags static_all \
 * Credential
   * Creates a new Credential on the App and associates all Access Requests products to it
 
-### Quota enforcement
+## Discovery Mode - Product
 
-The provisioning process will set quota values on the created Product when handling Access Requests. In order for Apigee to enforce quota based on the values set in teh Product a Quota Enforcement Policy needs to be set on the deployed Proxy.
+This mode can be setting the `APIGEE_DISCOVERYMODE` environment variable to `product`
+
+### Product discovery
+
+* Find all specs
+  * Parsing is not necessary in this mode
+  * Save info to cache
+* Find all Products defined
+  * Using the `APIGEE_FILTER` determine if the product should be discovered
+  * Using the product's name or display name, match it to a spec (case insensitive)
+  * If a spec is found create an API Service
+    * Use product definition, add attributes to Service
+    * Donwload and attach spec file
+
+### Product provisioning
+
+* Managed Application
+  * Creates a new App on Apigee under the configured developer
+* Access Request
+  * Creates a new Product, or uses existing, using the product associated with the API Service as a template
+  * Associates the new Product to any existing Credentials on the Application
+* Credential
+  * Creates a new Credential on the App and associates all Access Requests products to it
+  
+## Quota enforcement
+
+In both modes the provisioning process will set quota values on the created Product when handling Access Requests. In order for Apigee to enforce quota based on the values set in teh Product a Quota Enforcement Policy needs to be set on the deployed Proxy.
 
 Here is a sample Quota policy that may be added to the desired Proxies.
 
@@ -100,19 +132,23 @@ Here is a sample Quota policy that may be added to the desired Proxies.
 * TimeUnit - in this case using the API Key policy gets the quota time unit from the product definition
 Í
 
-| Environment Variable       | Description                                               | Default (if applicable)           |
-| -------------------------- | --------------------------------------------------------- | --------------------------------- |
-| APIGEE_URL                 | The base Apigee URL for this agent to connect to          | https://api.enterprise.apigee.com |
-| APIGEE_APIVERSION          | The version of the API for the agent to use               | v1                                |
-| APIGEE_DATAURL             | The base Apigee Data API URL for this agent to connect to | https://apigee.com/dapi/api       |
-| APIGEE_ORGANIZATION        | The Apigee organization name                              |                                   |
-| APIGEE_DEVELOPERID         | The Apigee developer, email, that will own all apps       |                                   |
-| APIGEE_INTERVAL_PROXY      | The polling interval checking for API Proxy changes       | 30s (30 seconds)                  |
-| APIGEE_INTERVAL_SPEC       | The polling interval for checking for new Specs           | 30m (30 minute)                   |
-| APIGEE_WORKERS_PROXY       | The number of workers processing API Proxies              | 10                                |
-| APIGEE_WORKERS_SPEC        | The number of workers processing API Specs                | 15                                |
-| APIGEE_AUTH_USERNAME       | The Apigee account username/email address                 |                                   |
-| APIGEE_AUTH_PASSWORD       | The Apigee account password                               |                                   |
-| APIGEE_AUTH_URL            | The IDP URL                                               | https://login.apigee.com          |
-| APIGEE_AUTH_SERVERUSERNAME | The IDP username for requesting tokens                    | edgecli                           |
-| APIGEE_AUTH_SERVERPASSWORD | The IDP password for requesting tokens                    | edgeclisecret                     |
+| Environment Variable       | Description                                                                          | Default (if applicable)           |
+| -------------------------- | ------------------------------------------------------------------------------------ | --------------------------------- |
+| APIGEE_URL                 | The base Apigee URL for this agent to connect to                                     | https://api.enterprise.apigee.com |
+| APIGEE_APIVERSION          | The version of the API for the agent to use                                          | v1                                |
+| APIGEE_DATAURL             | The base Apigee Data API URL for this agent to connect to                            | https://apigee.com/dapi/api       |
+| APIGEE_ORGANIZATION        | The Apigee organization name                                                         |                                   |
+| APIGEE_DEVELOPERID         | The Apigee developer, email, that will own all apps                                  |                                   |
+| APIGEE_DISCOVERYMODE       | The mode in which the agent operates, discover proxies (proxy) or products (product) | proxy                             |
+| APIGEE_FILTER              | The tag filter to use against an Apigee product's attributes, only in product mode   |                                   |
+| APIGEE_INTERVAL_PROXY      | The polling interval checking for API Proxy changes, only in proxy mode              | 30s (30 seconds)                  |
+| APIGEE_INTERVAL_PRODUCT    | The polling interval checking for Product changes, only in product mode              | 30s (30 seconds)                  |
+| APIGEE_INTERVAL_SPEC       | The polling interval for checking for new Specs                                      | 30m (30 minute)                   |
+| APIGEE_WORKERS_PROXY       | The number of workers processing API Proxies, only in proxy mode                     | 10                                |
+| APIGEE_WORKERS_PRODUCT     | The number of workers processing Products, only in product mode                      | 10                                |
+| APIGEE_WORKERS_SPEC        | The number of workers processing API Specs                                           | 20                                |
+| APIGEE_AUTH_USERNAME       | The Apigee account username/email address                                            |                                   |
+| APIGEE_AUTH_PASSWORD       | The Apigee account password                                                          |                                   |
+| APIGEE_AUTH_URL            | The IDP URL                                                                          | https://login.apigee.com          |
+| APIGEE_AUTH_SERVERUSERNAME | The IDP username for requesting tokens                                               | edgecli                           |
+| APIGEE_AUTH_SERVERPASSWORD | The IDP password for requesting tokens                                               | edgeclisecret                     |

--- a/discovery/pkg/apigee/agent.go
+++ b/discovery/pkg/apigee/agent.go
@@ -88,7 +88,7 @@ func (a *Agent) registerJobs() error {
 		// register the api validator job
 		validatorReady = proxiesJob.FirstRunComplete
 	} else {
-		productsJob := newPollProductsJob(a.apigeeClient, a.agentCache, specsJob.FirstRunComplete, a.cfg.ApigeeCfg.GetWorkers().Product)
+		productsJob := newPollProductsJob(a.apigeeClient, a.agentCache, specsJob.FirstRunComplete, a.cfg.ApigeeCfg.GetWorkers().Product, a.shouldPushAPI)
 		_, err = jobs.RegisterIntervalJobWithName(productsJob, a.apigeeClient.GetConfig().GetIntervals().Product, "Poll Products")
 		if err != nil {
 			return err
@@ -113,6 +113,12 @@ func (a *Agent) running() {
 // Stop - signals the agent to stop
 func (a *Agent) Stop() {
 	a.stopChan <- struct{}{}
+}
+
+// shouldPushAPI - callback used determine if the Product should be pushed to Central or not
+func (a *Agent) shouldPushAPI(attributes map[string]string) bool {
+	// Evaluate the filter condition
+	return a.discoveryFilter.Evaluate(attributes)
 }
 
 // apiValidator - registers the agent jobs

--- a/discovery/pkg/apigee/agent.go
+++ b/discovery/pkg/apigee/agent.go
@@ -69,22 +69,35 @@ func (a *Agent) Run() error {
 // registerJobs - registers the agent jobs
 func (a *Agent) registerJobs() error {
 	var err error
-	// createTopics()
 
-	specsJob := newPollSpecsJob(a.apigeeClient, a.agentCache, a.cfg.ApigeeCfg.GetWorkers().Proxy)
+	specsJob := newPollSpecsJob(a.apigeeClient, a.agentCache, a.cfg.ApigeeCfg.GetWorkers().Spec)
 	_, err = jobs.RegisterIntervalJobWithName(specsJob, a.apigeeClient.GetConfig().GetIntervals().Spec, "Poll Specs")
 	if err != nil {
 		return err
 	}
 
-	proxiesJob := newPollProxiesJob(a.apigeeClient, a.agentCache, specsJob.FirstRunComplete, a.cfg.ApigeeCfg.GetWorkers().Proxy)
-	_, err = jobs.RegisterIntervalJobWithName(proxiesJob, a.apigeeClient.GetConfig().GetIntervals().Proxy, "Poll Proxies")
-	if err != nil {
-		return err
-	}
+	var validatorReady jobFirstRunDone
 
-	// register the api validator job
-	_, err = jobs.RegisterSingleRunJobWithName(newRegisterAPIValidatorJob(proxiesJob.FirstRunComplete, a.registerValidator), "Register API Validator")
+	if a.cfg.ApigeeCfg.IsProxyMode() {
+		proxiesJob := newPollProxiesJob(a.apigeeClient, a.agentCache, specsJob.FirstRunComplete, a.cfg.ApigeeCfg.GetWorkers().Proxy)
+		_, err = jobs.RegisterIntervalJobWithName(proxiesJob, a.apigeeClient.GetConfig().GetIntervals().Proxy, "Poll Proxies")
+		if err != nil {
+			return err
+		}
+
+		// register the api validator job
+		validatorReady = proxiesJob.FirstRunComplete
+	} else {
+		productsJob := newPollProductsJob(a.apigeeClient, a.agentCache, specsJob.FirstRunComplete, a.cfg.ApigeeCfg.GetWorkers().Product)
+		_, err = jobs.RegisterIntervalJobWithName(productsJob, a.apigeeClient.GetConfig().GetIntervals().Product, "Poll Products")
+		if err != nil {
+			return err
+		}
+
+		// register the api validator job
+		validatorReady = productsJob.FirstRunComplete
+	}
+	_, err = jobs.RegisterSingleRunJobWithName(newRegisterAPIValidatorJob(validatorReady, a.registerValidator), "Register API Validator")
 
 	agent.NewAPIKeyCredentialRequestBuilder(agent.WithCRDIsSuspendable()).Register()
 	agent.NewAPIKeyAccessRequestBuilder().Register()
@@ -105,10 +118,7 @@ func (a *Agent) Stop() {
 // apiValidator - registers the agent jobs
 func (a *Agent) apiValidator(proxyName, envName string) bool {
 	// get the api with the product name and portal name
-	cacheKey := createProxyCacheKey(proxyName, envName)
-
-	_, err := a.agentCache.GetPublishedProxy(cacheKey)
-	return err == nil
+	return true
 }
 
 func (a *Agent) registerValidator() {

--- a/discovery/pkg/apigee/agent.go
+++ b/discovery/pkg/apigee/agent.go
@@ -70,7 +70,7 @@ func (a *Agent) Run() error {
 func (a *Agent) registerJobs() error {
 	var err error
 
-	specsJob := newPollSpecsJob(a.apigeeClient, a.agentCache, a.cfg.ApigeeCfg.GetWorkers().Spec)
+	specsJob := newPollSpecsJob(a.apigeeClient, a.agentCache, a.cfg.ApigeeCfg.GetWorkers().Spec, a.cfg.ApigeeCfg.IsProxyMode())
 	_, err = jobs.RegisterIntervalJobWithName(specsJob, a.apigeeClient.GetConfig().GetIntervals().Spec, "Poll Specs")
 	if err != nil {
 		return err

--- a/discovery/pkg/apigee/cache.go
+++ b/discovery/pkg/apigee/cache.go
@@ -2,6 +2,7 @@ package apigee
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Axway/agent-sdk/pkg/apic"
@@ -30,7 +31,7 @@ func newAgentCache() *agentCache {
 func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, endpoints ...string) {
 	item := specCacheItem{
 		ID:          id,
-		Name:        name,
+		Name:        strings.ToLower(name),
 		ContentPath: path,
 		ModDate:     modDate,
 	}
@@ -67,7 +68,7 @@ func (a *agentCache) GetSpecWithPath(path string) (*specCacheItem, error) {
 }
 
 func (a *agentCache) GetSpecWithName(name string) (*specCacheItem, error) {
-	data, err := a.cache.GetBySecondaryKey(name)
+	data, err := a.cache.GetBySecondaryKey(strings.ToLower(name))
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/pkg/apigee/cache.go
+++ b/discovery/pkg/apigee/cache.go
@@ -28,6 +28,10 @@ func newAgentCache() *agentCache {
 	}
 }
 
+func specPrimaryKey(name string) string {
+	return fmt.Sprintf("spec-%s", name)
+}
+
 func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, endpoints ...string) {
 	item := specCacheItem{
 		ID:          id,
@@ -36,9 +40,9 @@ func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, en
 		ModDate:     modDate,
 	}
 
-	a.cache.SetWithSecondaryKey(name, path, item)
-	a.cache.SetSecondaryKey(name, strings.ToLower(name))
-	a.cache.SetSecondaryKey(name, id)
+	a.cache.SetWithSecondaryKey(specPrimaryKey(name), path, item)
+	a.cache.SetSecondaryKey(specPrimaryKey(name), strings.ToLower(name))
+	a.cache.SetSecondaryKey(specPrimaryKey(name), id)
 	for _, ep := range endpoints {
 		if _, found := a.specEndpointToKeys[ep]; !found {
 			a.specEndpointToKeys[ep] = []specCacheItem{}
@@ -49,7 +53,7 @@ func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, en
 
 func (a *agentCache) HasSpecChanged(name string, modDate time.Time) bool {
 	data, err := a.cache.GetBySecondaryKey(name)
-	if err != nil {
+	if err != nil || data == nil {
 		// spec not in cache
 		return true
 	}
@@ -63,6 +67,9 @@ func (a *agentCache) GetSpecWithPath(path string) (*specCacheItem, error) {
 	if err != nil {
 		return nil, err
 	}
+	if data == nil {
+		return nil, fmt.Errorf("spec path name %s not found in cache", path)
+	}
 
 	specItem := data.(specCacheItem)
 	return &specItem, nil
@@ -72,6 +79,9 @@ func (a *agentCache) GetSpecWithName(name string) (*specCacheItem, error) {
 	data, err := a.cache.GetBySecondaryKey(strings.ToLower(name))
 	if err != nil {
 		return nil, err
+	}
+	if data == nil {
+		return nil, fmt.Errorf("spec with name %s not found in cache", name)
 	}
 
 	specItem := data.(specCacheItem)
@@ -95,6 +105,44 @@ func (a *agentCache) GetSpecPathWithEndpoint(endpoint string) (string, error) {
 	return latest.ContentPath, nil
 }
 
+func productPrimaryKey(name string) string {
+	return fmt.Sprintf("product-%s", name)
+}
+
+func (a *agentCache) AddProductToCache(name string, modDate time.Time, specModDate time.Time) {
+	item := productCacheItem{
+		Name:        strings.ToLower(name),
+		ModDate:     modDate,
+		SpecModDate: specModDate,
+	}
+
+	a.cache.Set(productPrimaryKey(name), item)
+}
+
+func (a *agentCache) HasProductChanged(name string, modDate time.Time, specModDate time.Time) bool {
+	data, err := a.cache.Get(productPrimaryKey(name))
+	if err != nil || data == nil {
+		// spec not in cache
+		return true
+	}
+
+	productItem := data.(productCacheItem)
+	return (modDate.After(productItem.ModDate) || specModDate.After(productItem.SpecModDate))
+}
+
+func (a *agentCache) GetProductWithName(name string) (*productCacheItem, error) {
+	data, err := a.cache.Get(productPrimaryKey(name))
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, fmt.Errorf("product with name %s not found in cache", name)
+	}
+
+	productItem := data.(productCacheItem)
+	return &productItem, nil
+}
+
 func (a *agentCache) AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody) {
 	a.cache.Set(cacheKey, serviceBody)
 }
@@ -103,6 +151,9 @@ func (a *agentCache) GetPublishedProxy(cacheKey string) (*apic.ServiceBody, erro
 	item, err := a.cache.Get(cacheKey)
 	if err != nil {
 		return nil, err
+	}
+	if item == nil {
+		return nil, fmt.Errorf("published proxy with key %s not found in cache", cacheKey)
 	}
 
 	sb := item.(*apic.ServiceBody)

--- a/discovery/pkg/apigee/cache.go
+++ b/discovery/pkg/apigee/cache.go
@@ -14,7 +14,8 @@ type agentCache struct {
 }
 
 type specCacheItem struct {
-	Hash        uint64
+	ID          string
+	Name        string
 	ContentPath string
 	ModDate     time.Time
 }
@@ -26,14 +27,16 @@ func newAgentCache() *agentCache {
 	}
 }
 
-func (a *agentCache) AddSpecToCache(id, path string, contentHash uint64, modDate time.Time, endpoints ...string) {
+func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, endpoints ...string) {
 	item := specCacheItem{
-		Hash:        contentHash,
+		ID:          id,
+		Name:        name,
 		ContentPath: path,
 		ModDate:     modDate,
 	}
 
 	a.cache.SetWithSecondaryKey(id, path, item)
+	a.cache.SetSecondaryKey(id, name)
 	for _, ep := range endpoints {
 		if _, found := a.specEndpointToKeys[ep]; !found {
 			a.specEndpointToKeys[ep] = []specCacheItem{}
@@ -42,14 +45,35 @@ func (a *agentCache) AddSpecToCache(id, path string, contentHash uint64, modDate
 	}
 }
 
-func (a *agentCache) GetSpecWithPath(path string) (string, error) {
-	data, err := a.cache.GetBySecondaryKey(path)
+func (a *agentCache) HasSpecChanged(id string, modDate time.Time) bool {
+	data, err := a.cache.Get(id)
 	if err != nil {
-		return "", err
+		// spec not in cache
+		return true
 	}
 
 	specItem := data.(specCacheItem)
-	return specItem.ContentPath, nil
+	return modDate.After(specItem.ModDate)
+}
+
+func (a *agentCache) GetSpecWithPath(path string) (*specCacheItem, error) {
+	data, err := a.cache.GetBySecondaryKey(path)
+	if err != nil {
+		return nil, err
+	}
+
+	specItem := data.(specCacheItem)
+	return &specItem, nil
+}
+
+func (a *agentCache) GetSpecWithName(name string) (*specCacheItem, error) {
+	data, err := a.cache.GetBySecondaryKey(name)
+	if err != nil {
+		return nil, err
+	}
+
+	specItem := data.(specCacheItem)
+	return &specItem, nil
 }
 
 // GetSpecPathWithEndpoint - returns the lat modified spec found with this endpoint
@@ -69,7 +93,7 @@ func (a *agentCache) GetSpecPathWithEndpoint(endpoint string) (string, error) {
 	return latest.ContentPath, nil
 }
 
-func (a *agentCache) AddPublishedProxyToCache(cacheKey string, serviceBody *apic.ServiceBody) {
+func (a *agentCache) AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody) {
 	a.cache.Set(cacheKey, serviceBody)
 }
 

--- a/discovery/pkg/apigee/cache.go
+++ b/discovery/pkg/apigee/cache.go
@@ -36,8 +36,9 @@ func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, en
 		ModDate:     modDate,
 	}
 
-	a.cache.SetWithSecondaryKey(id, path, item)
-	a.cache.SetSecondaryKey(id, name)
+	a.cache.SetWithSecondaryKey(name, path, item)
+	a.cache.SetSecondaryKey(name, strings.ToLower(name))
+	a.cache.SetSecondaryKey(name, id)
 	for _, ep := range endpoints {
 		if _, found := a.specEndpointToKeys[ep]; !found {
 			a.specEndpointToKeys[ep] = []specCacheItem{}
@@ -46,8 +47,8 @@ func (a *agentCache) AddSpecToCache(id, path, name string, modDate time.Time, en
 	}
 }
 
-func (a *agentCache) HasSpecChanged(id string, modDate time.Time) bool {
-	data, err := a.cache.Get(id)
+func (a *agentCache) HasSpecChanged(name string, modDate time.Time) bool {
+	data, err := a.cache.GetBySecondaryKey(name)
 	if err != nil {
 		// spec not in cache
 		return true

--- a/discovery/pkg/apigee/cache_test.go
+++ b/discovery/pkg/apigee/cache_test.go
@@ -1,0 +1,89 @@
+package apigee
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cacheSpecs(t *testing.T) {
+	// create new agent cache
+	c := newAgentCache()
+	assert.NotNil(t, c)
+
+	// add specs to cache
+	c.AddSpecToCache("id1", "/path/id1", "name-id1", time.Now())
+	c.AddSpecToCache("id2", "/path/id2", "name-id2", time.Now(), "http://id2/endpoint1", "http://id2/endpoint2")
+
+	// get spec items
+
+	// exists
+	//path
+	item, err := c.GetSpecWithPath("/path/id1")
+	assert.NotNil(t, item)
+	assert.Nil(t, err)
+	//name
+	item, err = c.GetSpecWithName("name-id2")
+	assert.NotNil(t, item)
+	assert.Nil(t, err)
+	//endpoint
+	path, err := c.GetSpecPathWithEndpoint("http://id2/endpoint1")
+	assert.NotEmpty(t, path)
+	assert.Nil(t, err)
+
+	// not exists
+	//path
+	item, err = c.GetSpecWithPath("/path/id3")
+	assert.Nil(t, item)
+	assert.NotNil(t, err)
+	//name
+	item, err = c.GetSpecWithName("name-id3")
+	assert.Nil(t, item)
+	assert.NotNil(t, err)
+	//endpoint
+	path, err = c.GetSpecPathWithEndpoint("http://id2/endpoint3")
+	assert.Empty(t, path)
+	assert.NotNil(t, err)
+
+	// has spec changed
+	changed := c.HasSpecChanged("name-id1", time.Now().Add(time.Hour))
+	assert.True(t, changed)
+	changed = c.HasSpecChanged("name-id1", time.Now().Add(-1*time.Hour))
+	assert.False(t, changed)
+	changed = c.HasSpecChanged("name-id3", time.Now().Add(-1*time.Hour)) // doesn't exist is changed
+	assert.True(t, changed)
+}
+
+func Test_cacheProducts(t *testing.T) {
+	// create new agent cache
+	c := newAgentCache()
+	assert.NotNil(t, c)
+
+	// add products to cache
+	c.AddProductToCache("prod1", time.Now(), time.Now())
+
+	// get product item
+	//exists
+	item, err := c.GetProductWithName("prod1")
+	assert.NotNil(t, item)
+	assert.Nil(t, err)
+	//not exists
+	item, err = c.GetProductWithName("prod2")
+	assert.Nil(t, item)
+	assert.NotNil(t, err)
+
+	// has product changed
+	//product change
+	changed := c.HasProductChanged("prod1", time.Now().Add(time.Hour), time.Now().Add(-1*time.Hour))
+	assert.True(t, changed)
+	//spec change
+	changed = c.HasProductChanged("prod1", time.Now().Add(-1*time.Hour), time.Now().Add(time.Hour))
+	assert.True(t, changed)
+	//no change
+	changed = c.HasProductChanged("prod1", time.Now().Add(-1*time.Hour), time.Now().Add(-1*time.Hour))
+	assert.False(t, changed)
+	//spec change
+	changed = c.HasProductChanged("prod2", time.Now().Add(-1*time.Hour), time.Now().Add(-1*time.Hour)) // no match returns changed
+	assert.True(t, changed)
+}

--- a/discovery/pkg/apigee/definitions.go
+++ b/discovery/pkg/apigee/definitions.go
@@ -9,7 +9,7 @@ type Association struct {
 	URL string `json:"url"`
 }
 
-type JobFirstRunDone func() bool
+type jobFirstRunDone func() bool
 
 const (
 	quotaPolicy  = "Quota"

--- a/discovery/pkg/apigee/pollproductsjob.go
+++ b/discovery/pkg/apigee/pollproductsjob.go
@@ -1,0 +1,204 @@
+package apigee
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Axway/agent-sdk/pkg/agent"
+	"github.com/Axway/agent-sdk/pkg/apic"
+	"github.com/Axway/agent-sdk/pkg/jobs"
+	coreutil "github.com/Axway/agent-sdk/pkg/util"
+	"github.com/Axway/agent-sdk/pkg/util/log"
+
+	"github.com/Axway/agents-apigee/client/pkg/apigee"
+	"github.com/Axway/agents-apigee/client/pkg/apigee/models"
+	"github.com/Axway/agents-apigee/discovery/pkg/util"
+)
+
+const (
+	productNameField    ctxKeys = "product"
+	productDetailsField ctxKeys = "productDetails"
+)
+
+type productClient interface {
+	GetProducts() (apigee.Products, error)
+	GetProduct(productName string) (*models.ApiProduct, error)
+	GetSpecFile(specPath string) ([]byte, error)
+	IsReady() bool
+}
+
+type productCache interface {
+	GetSpecWithName(name string) (*specCacheItem, error)
+	AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody)
+}
+
+// job that will poll for any new portals on APIGEE Edge
+type pollProductsJob struct {
+	jobs.Job
+	client      productClient
+	cache       productCache
+	firstRun    bool
+	specsReady  jobFirstRunDone
+	pubLock     sync.Mutex
+	publishFunc agent.PublishAPIFunc
+	logger      log.FieldLogger
+	workers     int
+}
+
+func newPollProductsJob(client productClient, cache productCache, specsReady jobFirstRunDone, workers int) *pollProductsJob {
+	job := &pollProductsJob{
+		client:      client,
+		cache:       cache,
+		firstRun:    true,
+		specsReady:  specsReady,
+		logger:      log.NewFieldLogger().WithComponent("pollProducts").WithPackage("apigee"),
+		publishFunc: agent.PublishAPI,
+		workers:     workers,
+	}
+	return job
+}
+
+func (j *pollProductsJob) Ready() bool {
+	j.logger.Trace("checking if the apigee client is ready for calls")
+	if !j.client.IsReady() {
+		return false
+	}
+
+	j.logger.Trace("checking if specs have been cached")
+	return j.specsReady()
+}
+
+func (j *pollProductsJob) Status() error {
+	return nil
+}
+
+func (j *pollProductsJob) Execute() error {
+	j.logger.Trace("executing")
+	products, err := j.client.GetProducts()
+	if err != nil {
+		j.logger.WithError(err).Error("getting products")
+		return err
+	}
+
+	limiter := make(chan string, j.workers)
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(products))
+	for _, p := range products {
+		go func() {
+			defer wg.Done()
+			name := <-limiter
+			j.handleProduct(name)
+		}()
+		limiter <- p
+	}
+
+	wg.Wait()
+	close(limiter)
+
+	return nil
+}
+
+func (j *pollProductsJob) FirstRunComplete() bool {
+	return !j.firstRun
+}
+
+func (j *pollProductsJob) handleProduct(productName string) {
+	logger := j.logger.WithField(productNameField.String(), productName)
+	logger.Trace("handling product")
+
+	// get product full details
+	ctx := addLoggerToContext(context.Background(), logger)
+	ctx = context.WithValue(ctx, productNameField, productName)
+
+	// try to get spec by using the name of the product
+	specDetails, err := j.cache.GetSpecWithName(productName)
+	if err != nil {
+		logger.WithError(err).Trace("could not find spec for product by name")
+		return
+	}
+	ctx = context.WithValue(ctx, specPathField, specDetails.ContentPath)
+
+	// get the full product details
+	productDetails, err := j.client.GetProduct(productName)
+	if err != nil {
+		logger.WithError(err).Trace("could not retrieve product details")
+		return
+	}
+	ctx = context.WithValue(ctx, productDetailsField, productDetails)
+
+	// create service
+	serviceBody, err := j.buildServiceBody(ctx)
+	if err != nil {
+		logger.WithError(err).Error("building service body")
+		return
+	}
+	serviceBodyHash, _ := coreutil.ComputeHash(*serviceBody)
+	hashString := util.ConvertUnitToString(serviceBodyHash)
+	cacheKey := createProductCacheKey(productName)
+
+	// Check DiscoveryCache for API
+	j.pubLock.Lock() // only publish one at a time
+	defer j.pubLock.Unlock()
+	value := agent.GetAttributeOnPublishedAPIByID(productName, "hash")
+
+	err = nil
+	if !agent.IsAPIPublishedByID(productName) {
+		// call new API
+		err = j.publishAPI(*serviceBody, hashString, cacheKey)
+	} else if value != hashString {
+		// handle update
+		log.Tracef("%s has been updated, push new revision", productName)
+		serviceBody.APIUpdateSeverity = "Major"
+		serviceBody.SpecDefinition = []byte{}
+		log.Tracef("%+v", serviceBody)
+		err = j.publishAPI(*serviceBody, hashString, cacheKey)
+	}
+
+	if err == nil {
+		j.cache.AddPublishedServiceToCache(cacheKey, serviceBody)
+	}
+}
+
+func (j *pollProductsJob) buildServiceBody(ctx context.Context) (*apic.ServiceBody, error) {
+	logger := getLoggerFromContext(ctx)
+	product := ctx.Value(productDetailsField).(*models.ApiProduct)
+	specPath := getStringFromContext(ctx, specPathField)
+
+	// get the spec to build the service body
+	spec, err := j.client.GetSpecFile(specPath)
+	if err != nil {
+		logger.WithError(err).Error("could not download spec")
+		return nil, err
+	}
+
+	if len(spec) == 0 {
+		return nil, fmt.Errorf("spec had no content")
+	}
+
+	logger.Debug("creating service body")
+
+	sb, err := apic.NewServiceBodyBuilder().
+		SetID(product.Name).
+		SetAPIName(product.Name).
+		SetDescription(product.Description).
+		SetAPISpec(spec).
+		SetTitle(product.DisplayName).
+		Build()
+	return &sb, err
+}
+
+func (j *pollProductsJob) publishAPI(serviceBody apic.ServiceBody, hashString, cacheKey string) error {
+	// Add a few more attributes to the service body
+	serviceBody.ServiceAttributes["GatewayType"] = gatewayType
+	serviceBody.ServiceAgentDetails["hash"] = hashString
+	serviceBody.InstanceAgentDetails[cacheKeyAttribute] = cacheKey
+
+	err := j.publishFunc(serviceBody)
+	if err == nil {
+		log.Infof("Published API %s to AMPLIFY Central", serviceBody.NameToPush)
+		return err
+	}
+	return nil
+}

--- a/discovery/pkg/apigee/pollproductsjob.go
+++ b/discovery/pkg/apigee/pollproductsjob.go
@@ -3,6 +3,7 @@ package apigee
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/Axway/agent-sdk/pkg/agent"
@@ -17,8 +18,9 @@ import (
 )
 
 const (
-	productNameField    ctxKeys = "product"
-	productDetailsField ctxKeys = "productDetails"
+	productNameField        ctxKeys = "product"
+	productDisplayNameField ctxKeys = "productDisplay"
+	productDetailsField     ctxKeys = "productDetails"
 )
 
 type productClient interface {
@@ -33,31 +35,37 @@ type productCache interface {
 	AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody)
 }
 
+type IsPublishedFunc func(string) bool
+
 // job that will poll for any new portals on APIGEE Edge
 type pollProductsJob struct {
 	jobs.Job
-	client      productClient
-	cache       productCache
-	firstRun    bool
-	specsReady  jobFirstRunDone
-	pubLock     sync.Mutex
-	publishFunc agent.PublishAPIFunc
-	logger      log.FieldLogger
-	workers     int
-	running     bool
-	runningLock sync.Mutex
+	client          productClient
+	cache           productCache
+	firstRun        bool
+	specsReady      jobFirstRunDone
+	pubLock         sync.Mutex
+	isPublishedFunc IsPublishedFunc
+	publishFunc     agent.PublishAPIFunc
+	logger          log.FieldLogger
+	workers         int
+	running         bool
+	runningLock     sync.Mutex
+	shouldPushAPI   func(map[string]string) bool
 }
 
-func newPollProductsJob(client productClient, cache productCache, specsReady jobFirstRunDone, workers int) *pollProductsJob {
+func newPollProductsJob(client productClient, cache productCache, specsReady jobFirstRunDone, workers int, shouldPushAPI func(map[string]string) bool) *pollProductsJob {
 	job := &pollProductsJob{
-		client:      client,
-		cache:       cache,
-		firstRun:    true,
-		specsReady:  specsReady,
-		logger:      log.NewFieldLogger().WithComponent("pollProducts").WithPackage("apigee"),
-		publishFunc: agent.PublishAPI,
-		workers:     workers,
-		runningLock: sync.Mutex{},
+		client:          client,
+		cache:           cache,
+		firstRun:        true,
+		specsReady:      specsReady,
+		logger:          log.NewFieldLogger().WithComponent("pollProducts").WithPackage("apigee"),
+		isPublishedFunc: agent.IsAPIPublishedByID,
+		publishFunc:     agent.PublishAPI,
+		workers:         workers,
+		runningLock:     sync.Mutex{},
+		shouldPushAPI:   shouldPushAPI,
 	}
 	return job
 }
@@ -135,14 +143,6 @@ func (j *pollProductsJob) handleProduct(productName string) {
 	ctx := addLoggerToContext(context.Background(), logger)
 	ctx = context.WithValue(ctx, productNameField, productName)
 
-	// try to get spec by using the name of the product
-	specDetails, err := j.cache.GetSpecWithName(productName)
-	if err != nil {
-		logger.WithError(err).Trace("could not find spec for product by name")
-		return
-	}
-	ctx = context.WithValue(ctx, specPathField, specDetails.ContentPath)
-
 	// get the full product details
 	productDetails, err := j.client.GetProduct(productName)
 	if err != nil {
@@ -150,6 +150,21 @@ func (j *pollProductsJob) handleProduct(productName string) {
 		return
 	}
 	ctx = context.WithValue(ctx, productDetailsField, productDetails)
+	ctx = context.WithValue(ctx, productDisplayNameField, productDetails.DisplayName)
+	logger = logger.WithField(productDisplayNameField.String(), productDetails.DisplayName)
+
+	if !j.shouldPublishProduct(ctx) {
+		logger.Trace("product has been filtered out")
+		return
+	}
+
+	// try to get spec by using the name of the product
+	specDetails, err := j.getSpecDetails(ctx)
+	if err != nil {
+		logger.Trace("could not find spec for product by name")
+		return
+	}
+	ctx = context.WithValue(ctx, specPathField, specDetails.ContentPath)
 
 	// create service
 	serviceBody, err := j.buildServiceBody(ctx)
@@ -167,14 +182,13 @@ func (j *pollProductsJob) handleProduct(productName string) {
 	value := agent.GetAttributeOnPublishedAPIByID(productName, "hash")
 
 	err = nil
-	if !agent.IsAPIPublishedByID(productName) {
+	if !j.isPublishedFunc(productName) {
 		// call new API
 		err = j.publishAPI(*serviceBody, hashString, cacheKey)
 	} else if value != hashString {
 		// handle update
 		log.Tracef("%s has been updated, push new revision", productName)
 		serviceBody.APIUpdateSeverity = "Major"
-		serviceBody.SpecDefinition = []byte{}
 		log.Tracef("%+v", serviceBody)
 		err = j.publishAPI(*serviceBody, hashString, cacheKey)
 	}
@@ -182,6 +196,33 @@ func (j *pollProductsJob) handleProduct(productName string) {
 	if err == nil {
 		j.cache.AddPublishedServiceToCache(cacheKey, serviceBody)
 	}
+}
+
+func (j *pollProductsJob) shouldPublishProduct(ctx context.Context) bool {
+	product := ctx.Value(productDetailsField).(*models.ApiProduct)
+	// get the product attributes in a map
+	attributes := make(map[string]string)
+	for _, att := range product.Attributes {
+		// ignore access attribute
+		if strings.ToLower(att.Name) == "access" {
+			continue
+		}
+		attributes[att.Name] = att.Value
+	}
+	j.logger.WithField("Attributes", attributes).Trace("checking against discovery filter")
+	return j.shouldPushAPI(attributes)
+}
+
+func (j *pollProductsJob) getSpecDetails(ctx context.Context) (*specCacheItem, error) {
+	productName := getStringFromContext(ctx, productNameField)
+	displayName := getStringFromContext(ctx, productDisplayNameField)
+
+	specDetails, err := j.cache.GetSpecWithName(productName)
+	if err != nil {
+		// try to find the spec details with the display name before giving up
+		specDetails, err = j.cache.GetSpecWithName(displayName)
+	}
+	return specDetails, err
 }
 
 func (j *pollProductsJob) buildServiceBody(ctx context.Context) (*apic.ServiceBody, error) {
@@ -200,6 +241,14 @@ func (j *pollProductsJob) buildServiceBody(ctx context.Context) (*apic.ServiceBo
 		return nil, fmt.Errorf("spec had no content")
 	}
 
+	// create attributes to be added to service
+	serviceAttributes := make(map[string]string)
+	for _, att := range product.Attributes {
+		name := strings.ToLower(att.Name)
+		name = strings.ReplaceAll(name, " ", "_")
+		serviceAttributes[name] = att.Value
+	}
+
 	logger.Debug("creating service body")
 
 	sb, err := apic.NewServiceBodyBuilder().
@@ -208,6 +257,7 @@ func (j *pollProductsJob) buildServiceBody(ctx context.Context) (*apic.ServiceBo
 		SetDescription(product.Description).
 		SetAPISpec(spec).
 		SetTitle(product.DisplayName).
+		SetServiceAttribute(serviceAttributes).
 		Build()
 	return &sb, err
 }

--- a/discovery/pkg/apigee/pollproductsjob.go
+++ b/discovery/pkg/apigee/pollproductsjob.go
@@ -209,7 +209,7 @@ func (j *pollProductsJob) shouldPublishProduct(ctx context.Context) bool {
 		}
 		attributes[att.Name] = att.Value
 	}
-	j.logger.WithField("Attributes", attributes).Trace("checking against discovery filter")
+	j.logger.WithField("attributes", attributes).Trace("checking against discovery filter")
 	return j.shouldPushAPI(attributes)
 }
 

--- a/discovery/pkg/apigee/pollproductsjob_test.go
+++ b/discovery/pkg/apigee/pollproductsjob_test.go
@@ -235,3 +235,14 @@ func (m mockProductCache) GetSpecWithName(name string) (*specCacheItem, error) {
 
 func (m mockProductCache) AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody) {
 }
+
+func (m mockProductCache) AddProductToCache(name string, modDate time.Time, specModDate time.Time) {
+}
+
+func (m mockProductCache) HasProductChanged(name string, modDate time.Time, specModDate time.Time) bool {
+	return true
+}
+
+func (m mockProductCache) GetProductWithName(name string) (*productCacheItem, error) {
+	return nil, nil
+}

--- a/discovery/pkg/apigee/pollproductsjob_test.go
+++ b/discovery/pkg/apigee/pollproductsjob_test.go
@@ -1,0 +1,237 @@
+package apigee
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Axway/agent-sdk/pkg/apic"
+	"github.com/Axway/agents-apigee/client/pkg/apigee"
+	"github.com/Axway/agents-apigee/client/pkg/apigee/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_pollProductsJob(t *testing.T) {
+	tests := []struct {
+		name           string
+		productName    string
+		allProductErr  bool
+		getProductErr  bool
+		specNotFound   bool
+		filterFailed   bool
+		specNotInCache bool
+		apiPublished   bool
+	}{
+		{
+			name:         "api already published create update",
+			apiPublished: true,
+		},
+		{
+			name:        "api published with display name match",
+			productName: "priv-PushNotif",
+		},
+		{
+			name:        "api published with case insensitive name match",
+			productName: "cell",
+		},
+		{
+			name: "api published with name match",
+		},
+		{
+			name:           "do not publish when spec was not in the cache",
+			specNotInCache: true,
+		},
+		{
+			name:         "do not publish when should publish check fails",
+			filterFailed: true,
+		},
+		{
+			name:          "should stop when getting product details fails",
+			getProductErr: true,
+		},
+		{
+			name:          "should stop when getting all products fails",
+			allProductErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := mockProductClient{
+				t:             t,
+				productName:   tc.productName,
+				allProductErr: tc.allProductErr,
+				getProductErr: tc.getProductErr,
+				specNotFound:  tc.specNotFound,
+			}
+
+			cache := mockProductCache{
+				specNotInCache: tc.specNotInCache,
+			}
+
+			readyFunc := func() bool {
+				return true
+			}
+
+			filterFunc := func(map[string]string) bool {
+				return !tc.filterFailed
+			}
+
+			productJob := newPollProductsJob(client, cache, readyFunc, 10, filterFunc)
+			assert.False(t, productJob.FirstRunComplete())
+
+			productJob.isPublishedFunc = func(id string) bool {
+				return tc.apiPublished
+			}
+
+			publishCalled := false
+			// receive the publish call and validate what was published
+			productJob.publishFunc = func(sb apic.ServiceBody) error {
+				publishCalled = true
+				return nil
+			}
+
+			err := productJob.Execute()
+			if tc.allProductErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			// error getting all proxies should not flip first run
+			if tc.allProductErr || tc.getProductErr || tc.filterFailed || tc.specNotInCache {
+				assert.False(t, publishCalled)
+			} else {
+				assert.True(t, publishCalled)
+			}
+		})
+	}
+}
+
+type mockProductClient struct {
+	t             *testing.T
+	productName   string
+	allProductErr bool
+	getProductErr bool
+	specNotFound  bool
+}
+
+func (m mockProductClient) GetProducts() (products apigee.Products, err error) {
+	productName := m.productName
+	if productName == "" {
+		productName = "RTE"
+	}
+
+	products = []string{productName}
+	if m.allProductErr {
+		products = nil
+		err = fmt.Errorf("error get all products")
+	}
+	return
+}
+
+func (m mockProductClient) GetProduct(productName string) (*models.ApiProduct, error) {
+	products := map[string]*models.ApiProduct{
+		"RTE": {ApiResources: []string{},
+			ApprovalType: "auto",
+			Attributes: []models.Attribute{
+				{
+					Name:  "access",
+					Value: "public",
+				},
+			},
+			CreatedAt:      1665416157626,
+			CreatedBy:      "cicd_technical_user@engie.com",
+			Description:    "Generated Product",
+			DisplayName:    "RTE",
+			Environments:   []string{"acc", "int", "itt", "ppd"},
+			LastModifiedAt: 1665758109625,
+			LastModifiedBy: "cicd_technical_user@engie.com",
+			Name:           "RTE",
+			Proxies:        []string{"public-apiset-protected-ecowatt-v10"},
+			Quota:          "10000",
+			QuotaInterval:  "1",
+			QuotaTimeUnit:  "minute",
+			Scopes:         []string{"apihour:read", "apihour:write"},
+		},
+		"cell": {ApiResources: []string{"/"},
+			ApprovalType: "auto",
+			Attributes: []models.Attribute{
+				{
+					Name:  "access",
+					Value: "public",
+				},
+			},
+			CreatedAt:      1632752367332,
+			CreatedBy:      "cicd_technical_user@engie.com",
+			Description:    "Generated Product",
+			DisplayName:    "Cell",
+			Environments:   []string{"acc", "int", "itt", "ppd"},
+			LastModifiedAt: 1665758109625,
+			LastModifiedBy: "cicd_technical_user@engie.com",
+			Name:           "cell",
+			Proxies: []string{
+				"public-cel-portefeuilles-contrats-v01",
+				"public-cel-portefeuilles-contrats-v10",
+				"public-cel-protected-adlperformance-v01",
+				"public-cel-protected-pilotage-v01",
+				"public-cel-protected-v01",
+			},
+			Quota:         "10000",
+			QuotaInterval: "1",
+			QuotaTimeUnit: "minute",
+			Scopes:        []string{"apihour:read", "apihour:write"},
+		},
+		"priv-PushNotif": {ApiResources: []string{"/"},
+			ApprovalType: "auto",
+			Attributes: []models.Attribute{
+				{
+					Name:  "access",
+					Value: "public",
+				},
+			},
+			CreatedAt:      1632752359124,
+			CreatedBy:      "cicd_technical_user@engie.com",
+			Description:    "Generated Product",
+			DisplayName:    "Private-PushNotif",
+			Environments:   []string{"acc", "int", "itt", "ppd"},
+			LastModifiedAt: 1665758129808,
+			LastModifiedBy: "cicd_technical_user@engie.com",
+			Name:           "priv-PushNotif",
+			Proxies:        []string{"private-pushnotif-protected-airship-v10"},
+			Quota:          "10000",
+			QuotaInterval:  "1",
+			QuotaTimeUnit:  "minute",
+			Scopes:         []string{"apihour:read", "apihour:write"},
+		},
+	}
+	if m.getProductErr {
+		return nil, fmt.Errorf("error get product")
+	}
+	return products[productName], nil
+}
+
+func (m mockProductClient) GetSpecFile(path string) ([]byte, error) {
+	assert.Equal(m.t, specPath, path)
+	return []byte("spec"), nil
+}
+
+func (m mockProductClient) IsReady() bool { return false }
+
+type mockProductCache struct {
+	specNotInCache bool
+}
+
+func (m mockProductCache) GetSpecWithName(name string) (*specCacheItem, error) {
+	if m.specNotInCache {
+		return nil, fmt.Errorf("spec not in cache")
+	}
+	return &specCacheItem{
+		ID:          "id",
+		Name:        "name",
+		ContentPath: "/path/to/spec",
+		ModDate:     time.Now(),
+	}, nil
+}
+
+func (m mockProductCache) AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody) {
+}

--- a/discovery/pkg/apigee/pollproxiesjob_test.go
+++ b/discovery/pkg/apigee/pollproxiesjob_test.go
@@ -250,6 +250,12 @@ func (m mockProxyClient) IsReady() bool { return false }
 
 type mockProxyCache struct{}
 
-func (m mockProxyCache) GetSpecWithPath(path string) (string, error)                             { return "", nil }
-func (m mockProxyCache) GetSpecPathWithEndpoint(endpoint string) (string, error)                 { return "", nil }
-func (m mockProxyCache) AddPublishedProxyToCache(cacheKey string, serviceBody *apic.ServiceBody) {}
+func (m mockProxyCache) GetSpecWithPath(path string) (*specCacheItem, error) {
+	return &specCacheItem{}, nil
+}
+
+func (m mockProxyCache) GetSpecPathWithEndpoint(endpoint string) (string, error) {
+	return "", nil
+}
+
+func (m mockProxyCache) AddPublishedServiceToCache(cacheKey string, serviceBody *apic.ServiceBody) {}

--- a/discovery/pkg/apigee/pollspecsjob.go
+++ b/discovery/pkg/apigee/pollspecsjob.go
@@ -115,6 +115,7 @@ func (j *pollSpecsJob) handleSpec(spec apigee.SpecDetails) {
 	logger := j.logger.WithField("specName", spec.Name).WithField("specID", spec.ID)
 	logger.Trace("handling spec")
 	modDate, _ := time.Parse("2006-01-02T15:04:05.000000Z", spec.Modified)
+	modDate = modDate.Truncate(time.Millisecond) // truncate the nanoseconds
 
 	if !j.cache.HasSpecChanged(spec.ID, modDate) {
 		logger.Trace("spec has not been modified")

--- a/discovery/pkg/apigee/pollspecsjob.go
+++ b/discovery/pkg/apigee/pollspecsjob.go
@@ -57,6 +57,12 @@ func (j *pollSpecsJob) Status() error {
 	return nil
 }
 
+func (j *pollSpecsJob) updateRunning(running bool) {
+	j.runningLock.Lock()
+	defer j.runningLock.Unlock()
+	j.running = running
+}
+
 func (j *pollSpecsJob) isRunning() bool {
 	j.runningLock.Lock()
 	defer j.runningLock.Unlock()

--- a/discovery/pkg/apigee/pollspecsjob.go
+++ b/discovery/pkg/apigee/pollspecsjob.go
@@ -114,7 +114,7 @@ func (j *pollSpecsJob) FirstRunComplete() bool {
 func (j *pollSpecsJob) handleSpec(spec apigee.SpecDetails) {
 	logger := j.logger.WithField("specName", spec.Name).WithField("specID", spec.ID)
 	logger.Trace("handling spec")
-	modDate, _ := time.Parse("2006-01-02T15:04:05.000Z", spec.Modified)
+	modDate, _ := time.Parse("2006-01-02T15:04:05.000000Z", spec.Modified)
 
 	if !j.cache.HasSpecChanged(spec.ID, modDate) {
 		logger.Trace("spec has not been modified")

--- a/discovery/pkg/apigee/registervalidatorjob.go
+++ b/discovery/pkg/apigee/registervalidatorjob.go
@@ -6,11 +6,11 @@ import (
 
 type registerAPIValidatorJob struct {
 	jobs.Job
-	proxiesReady      JobFirstRunDone
+	proxiesReady      jobFirstRunDone
 	registerValidator func()
 }
 
-func newRegisterAPIValidatorJob(proxiesReady JobFirstRunDone, registerValidator func()) *registerAPIValidatorJob {
+func newRegisterAPIValidatorJob(proxiesReady jobFirstRunDone, registerValidator func()) *registerAPIValidatorJob {
 	job := &registerAPIValidatorJob{
 		proxiesReady:      proxiesReady,
 		registerValidator: registerValidator,

--- a/discovery/pkg/apigee/util.go
+++ b/discovery/pkg/apigee/util.go
@@ -54,6 +54,10 @@ func createProxyCacheKey(id, envName string) string {
 	return fmt.Sprintf("apiproxy-%s-%s", envName, id)
 }
 
+func createProductCacheKey(name string) string {
+	return fmt.Sprintf("apiproduct-%s", name)
+}
+
 type ctxKeys string
 
 const (


### PR DESCRIPTION
- Added the following environment variables
  - APIGEE_DISCOVERYMODE - default is proxy, set to product to discover products and associate to specs by name
  - APIGEE_WORKERS_PRODUCT - default 10, adjust as needed
  - APIGEE_INTERVAL_PRODUCT - default 30s, adjust as needed
- Reintroduce the APIGEE_FILTER variable
- Product discovery mode that can be turned on to discover products rather than proxies, matches to specs in the spec repo by name match