### PR TITLE
ISSUE-122 - fix access request deprovisioning

### DIFF
--- a/client/pkg/apigee/provisioning.go
+++ b/client/pkg/apigee/provisioning.go
@@ -113,7 +113,7 @@ func (a *ApigeeClient) CreateAppCredential(appName, devID string, products []str
 	return appData, err
 }
 
-func (a *ApigeeClient) AddProductCredential(appName, devID, key string, cpr CredentialProvisionRequest) (*models.DeveloperAppCredentials, error) {
+func (a *ApigeeClient) AddCredentialProduct(appName, devID, key string, cpr CredentialProvisionRequest) (*models.DeveloperAppCredentials, error) {
 	data, err := json.Marshal(cpr)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (a *ApigeeClient) AddProductCredential(appName, devID, key string, cpr Cred
 
 	if response.Code != http.StatusOK {
 		return nil, fmt.Errorf(
-			"received an unexpected response code %d from Apigee while updating app credentials: %s", response.Code, response.Body,
+			"received an unexpected response code %d from Apigee while adding a product to an app credentials: %s", response.Code, response.Body,
 		)
 	}
 
@@ -141,7 +141,7 @@ func (a *ApigeeClient) AddProductCredential(appName, devID, key string, cpr Cred
 	return cred, err
 }
 
-func (a *ApigeeClient) RemoveProductCredential(appName, devID, key, productName string) error {
+func (a *ApigeeClient) RemoveCredentialProduct(appName, devID, key, productName string) error {
 	url := fmt.Sprintf("%s/developers/%s/apps/%s/keys/%s/apiproducts/%s", a.orgURL, devID, appName, key, productName)
 
 	response, err := a.newRequest(
@@ -153,7 +153,32 @@ func (a *ApigeeClient) RemoveProductCredential(appName, devID, key, productName 
 
 	if response.Code != http.StatusOK {
 		return fmt.Errorf(
-			"received an unexpected response code %d from Apigee while updating removing product from app credentials", response.Code,
+			"received an unexpected response code %d from Apigee while removing product from an app credentials", response.Code,
+		)
+	}
+
+	return err
+}
+
+func (a *ApigeeClient) UpdateCredentialProduct(appName, devID, key, productName string, enable bool) error {
+	url := fmt.Sprintf("%s/developers/%s/apps/%s/keys/%s/apiproducts/%s", a.orgURL, devID, appName, key, productName)
+
+	action := "revoke"
+	if enable {
+		action = "approve"
+	}
+
+	response, err := a.newRequest(
+		http.MethodPost, url,
+		WithDefaultHeaders(), WithQueryParam("action", action),
+	).Execute()
+	if err != nil {
+		return err
+	}
+
+	if response.Code != http.StatusOK {
+		return fmt.Errorf(
+			"received an unexpected response code %d from Apigee while updating a product on an app credentials", response.Code,
 		)
 	}
 

--- a/client/pkg/apigee/provisioning.go
+++ b/client/pkg/apigee/provisioning.go
@@ -176,7 +176,7 @@ func (a *ApigeeClient) UpdateCredentialProduct(appName, devID, key, productName 
 		return err
 	}
 
-	if response.Code != http.StatusOK {
+	if response.Code != http.StatusNoContent {
 		return fmt.Errorf(
 			"received an unexpected response code %d from Apigee while updating a product on an app credentials", response.Code,
 		)

--- a/discovery/docker/Dockerfile
+++ b/discovery/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Build image
 # golang:1.20.5-alpine3.18 linux/amd64 
-FROM docker.io/golang@sha256:e7cc33118f807c67d9f2dfc811cc2cc8b79b3687d0b4ac891dd59bb2a5e4a8d3 as builder
+FROM docker.io/golang@sha256:e7cc33118f807c67d9f2dfc811cc2cc8b79b3687d0b4ac891dd59bb2a5e4a8d3 AS builder
 
 ENV GOFLAGS "-mod=mod"
 ENV GOWORK "off"

--- a/discovery/pkg/apigee/provision.go
+++ b/discovery/pkg/apigee/provision.go
@@ -68,7 +68,7 @@ func (p provisioner) AccessRequestDeprovision(req prov.AccessRequest) prov.Reque
 	apiID := util.ToString(instDetails[defs.AttrExternalAPIID])
 	logger := p.logger.WithField("handler", "AccessRequestDeprovision").WithField("apiID", apiID).WithField("application", req.GetApplicationName())
 
-	if p.isProductMode {
+	if p.isProductMode && req.GetQuota() != nil && req.GetQuota().GetPlanName() != "" {
 		// append the plan name to the apiID
 		apiID = fmt.Sprintf("%s-%s", apiID, req.GetQuota().GetPlanName())
 	}

--- a/discovery/pkg/apigee/provision.go
+++ b/discovery/pkg/apigee/provision.go
@@ -416,7 +416,7 @@ func (p provisioner) CredentialDeprovision(req prov.CredentialRequest) prov.Requ
 
 // CredentialProvision - retrieves the app credentials for oauth or api key authentication
 func (p provisioner) CredentialProvision(req prov.CredentialRequest) (prov.RequestStatus, prov.Credential) {
-	logger := p.logger.WithField("handler", "CredentialDeprovision").WithField("application", req.GetApplicationName())
+	logger := p.logger.WithField("handler", "CredentialProvision").WithField("application", req.GetApplicationName())
 
 	logger.Info("provisioning credential")
 	ps := prov.NewRequestStatusBuilder()

--- a/discovery/pkg/apigee/provision_test.go
+++ b/discovery/pkg/apigee/provision_test.go
@@ -23,7 +23,7 @@ func TestAccessRequestDeprovision(t *testing.T) {
 		appName     string
 		apiID       string
 		getAppErr   error
-		rmCredErr   error
+		upCredErr   error
 		missingCred bool
 	}{
 		{
@@ -47,11 +47,11 @@ func TestAccessRequestDeprovision(t *testing.T) {
 			status:    provisioning.Error,
 		},
 		{
-			name:      "should fail to deprovision an access request when removing the credential",
+			name:      "should fail to deprovision an access request when revoking the credential",
 			appName:   "app-one",
 			apiID:     "abc-123",
 			status:    provisioning.Error,
-			rmCredErr: fmt.Errorf("error"),
+			upCredErr: fmt.Errorf("error"),
 		},
 		{
 			name:    "should return an error when the appName is not found",
@@ -82,7 +82,7 @@ func TestAccessRequestDeprovision(t *testing.T) {
 				t:           t,
 				devID:       "dev-id-123",
 				getAppErr:   tc.getAppErr,
-				rmCredErr:   tc.rmCredErr,
+				upCredErr:   tc.upCredErr,
 				app:         app,
 				appName:     tc.appName,
 				key:         app.Credentials[0].ConsumerKey,
@@ -118,6 +118,7 @@ func TestAccessRequestProvision(t *testing.T) {
 		getAppErr    error
 		addCredErr   error
 		addProdErr   error
+		upCredErr    error
 		existingProd bool
 		noCreds      bool
 		isApiLinked  bool
@@ -143,6 +144,15 @@ func TestAccessRequestProvision(t *testing.T) {
 			apiID:       "abc-123",
 			apiStage:    "prod",
 			status:      provisioning.Success,
+			isApiLinked: true,
+		},
+		{
+			name:        "should fail to deprovision an access request when the api is already linked but could not be enabled",
+			appName:     "app-one",
+			apiID:       "abc-123",
+			apiStage:    "prod",
+			status:      provisioning.Success,
+			upCredErr:   fmt.Errorf("error"),
 			isApiLinked: true,
 		},
 		{
@@ -198,6 +208,7 @@ func TestAccessRequestProvision(t *testing.T) {
 				devID:       "dev-id-123",
 				key:         key,
 				getAppErr:   tc.getAppErr,
+				upCredErr:   tc.upCredErr,
 				productName: tc.apiID,
 				t:           t,
 			}, 30, &mockCache{t: t}, false, false)
@@ -605,6 +616,7 @@ type mockClient struct {
 	productName  string
 	rmAppErr     error
 	rmCredErr    error
+	upCredErr    error
 	enable       bool
 	existingProd bool
 	t            *testing.T
@@ -683,7 +695,7 @@ func (m mockClient) UpdateCredentialProduct(appName, devID, key, productName str
 	assert.Equal(m.t, m.key, key)
 	assert.Equal(m.t, m.productName, productName)
 	assert.Equal(m.t, m.enable, enable)
-	return nil
+	return m.upCredErr
 }
 
 func (m mockClient) UpdateAppCredential(appName, devID, key string, enable bool) error {

--- a/discovery/pkg/apigee/provision_test.go
+++ b/discovery/pkg/apigee/provision_test.go
@@ -662,19 +662,28 @@ func (m mockClient) CreateAppCredential(appName, devID string, products []string
 	}, nil
 }
 
-func (m mockClient) AddProductCredential(appName, devID, key string, cpr apigee.CredentialProvisionRequest) (*models.DeveloperAppCredentials, error) {
+func (m mockClient) AddCredentialProduct(appName, devID, key string, cpr apigee.CredentialProvisionRequest) (*models.DeveloperAppCredentials, error) {
 	assert.Equal(m.t, m.appName, appName)
 	assert.Equal(m.t, m.devID, devID)
 	assert.Equal(m.t, m.key, key)
 	return nil, m.addCredErr
 }
 
-func (m mockClient) RemoveProductCredential(appName, devID, key, productName string) error {
+func (m mockClient) RemoveCredentialProduct(appName, devID, key, productName string) error {
 	assert.Equal(m.t, m.appName, appName)
 	assert.Equal(m.t, m.devID, devID)
 	assert.Equal(m.t, m.key, key)
 	assert.Equal(m.t, m.productName, productName)
 	return m.rmCredErr
+}
+
+func (m mockClient) UpdateCredentialProduct(appName, devID, key, productName string, enable bool) error {
+	assert.Equal(m.t, m.appName, appName)
+	assert.Equal(m.t, m.devID, devID)
+	assert.Equal(m.t, m.key, key)
+	assert.Equal(m.t, m.productName, productName)
+	assert.Equal(m.t, m.enable, enable)
+	return nil
 }
 
 func (m mockClient) UpdateAppCredential(appName, devID, key string, enable bool) error {

--- a/traceability/docker/Dockerfile
+++ b/traceability/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Build image
 # golang:1.20.5-alpine3.18 linux/amd64 
-FROM docker.io/golang@sha256:e7cc33118f807c67d9f2dfc811cc2cc8b79b3687d0b4ac891dd59bb2a5e4a8d3 as builder
+FROM docker.io/golang@sha256:e7cc33118f807c67d9f2dfc811cc2cc8b79b3687d0b4ac891dd59bb2a5e4a8d3 AS builder
 
 ENV GOFLAGS "-mod=mod"
 ENV GOWORK "off"


### PR DESCRIPTION
This was an issue specifically when a Central Product had a quota attached. The process for provisioning is the clone the Apigee Product renaming it to append the plan name. Then that cloned product is attached to the application. The deprovisioning was not accounting for the plan name appended Apigee Product, therefore not removing it from the applicaiton,