### PR TITLE
APIGOV-27481 - proxy discovery updates

### DIFF
--- a/client/pkg/apigee/specs.go
+++ b/client/pkg/apigee/specs.go
@@ -16,6 +16,9 @@ func (a *ApigeeClient) GetSpecFile(specPath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if response.Code != http.StatusOK {
+		return nil, fmt.Errorf("spec file not found at path")
+	}
 
 	return response.Body, nil
 }

--- a/client/pkg/config/config.go
+++ b/client/pkg/config/config.go
@@ -52,6 +52,7 @@ type ApigeeConfig struct {
 type ApigeeSpecConfig struct {
 	DisablePollForSpecs bool   `config:"disablePollForSpecs"`
 	Unstructured        bool   `config:"unstructured"`
+	MatchOnURL          bool   `config:"matchOnURL"`
 	LocalPath           string `config:"localDirectory"`
 	SpecExtensions      string `config:"extensions"`
 	Extensions          []string
@@ -125,6 +126,7 @@ const (
 	pathSpecWorkers             = "apigee.workers.spec"
 	pathProxyWorkers            = "apigee.workers.proxy"
 	pathProductWorkers          = "apigee.workers.product"
+	pathSpecMatchOnURL          = "apigee.specConfig.matchOnURL"
 	pathSpecLocalPath           = "apigee.specConfig.localPath"
 	pathSpecExtensions          = "apigee.specConfig.extensions"
 	pathSpecUnstructured        = "apigee.specConfig.unstructured"
@@ -156,6 +158,7 @@ func AddProperties(rootProps props) {
 	rootProps.AddIntProperty(pathProxyWorkers, 10, "Max number of workers discovering proxies")
 	rootProps.AddIntProperty(pathSpecWorkers, 20, "Max number of workers discovering specs")
 	rootProps.AddIntProperty(pathProductWorkers, 10, "Max number of workers discovering products")
+	rootProps.AddBoolProperty(pathSpecMatchOnURL, true, "Set to false to skip matching spec URLs to proxy URLs")
 	rootProps.AddStringProperty(pathSpecLocalPath, "", "Path to a local directory that contains the spec files")
 	rootProps.AddStringProperty(pathSpecExtensions, "json,yaml,yml", "Comma separated list of spec file extensions, needed for proxy mode")
 	rootProps.AddBoolProperty(pathSpecUnstructured, false, "Set to true to enable discovering apis that have no associated spec")
@@ -200,6 +203,7 @@ func ParseConfig(rootProps props) *ApigeeConfig {
 			BasicAuth:      rootProps.BoolPropertyValue(pathAuthBasicAuth),
 		},
 		Specs: &ApigeeSpecConfig{
+			MatchOnURL:          rootProps.BoolPropertyValue(pathSpecMatchOnURL),
 			LocalPath:           rootProps.StringPropertyValue(pathSpecLocalPath),
 			DisablePollForSpecs: rootProps.BoolPropertyValue(pathSpecDisablePollForSpecs),
 			Unstructured:        rootProps.BoolPropertyValue(pathSpecUnstructured),

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -104,32 +104,33 @@ Here is a sample Quota policy that may be added to the desired Proxies.
 * TimeUnit - in this case using the API Key policy gets the quota time unit from the product definition
 Í
 
-| Environment Variable                  | Description                                                                                     | Default (if applicable)           |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------- |
-| APIGEE_URL                            | The base Apigee URL for this agent to connect to                                                | https://api.enterprise.apigee.com |
-| APIGEE_APIVERSION                     | The version of the API for the agent to use                                                     | v1                                |
-| APIGEE_DATAURL                        | The base Apigee Data API URL for this agent to connect to                                       | https://apigee.com/dapi/api       |
-| APIGEE_ORGANIZATION                   | The Apigee organization name                                                                    |                                   |
-| APIGEE_DEVELOPERID                    | The Apigee developer, email, that will own all apps                                             |                                   |
-| APIGEE_DISCOVERYMODE                  | The mode in which the agent operates, discover proxies (proxy) or products (product)            | proxy                             |
-| APIGEE_FILTER                         | The tag filter to use against an Apigee product's attributes, only in product mode              |                                   |
-| APIGEE_CLONEATTRIBUTES                | Set this to true if the tags on a product should also be cloned on provisioning                 | false                             |
-| APIGEE_INTERVAL_PROXY                 | The polling interval checking for API Proxy changes, only in proxy mode                         | 30s (30 seconds), >=30s, <=5m     |
-| APIGEE_INTERVAL_PRODUCT               | The polling interval checking for Product changes, only in product mode                         | 30s (30 seconds), >=30s, <=5m     |
-| APIGEE_INTERVAL_SPEC                  | The polling interval for checking for new Specs                                                 | 30m (30 minute), >=1m             |
-| APIGEE_WORKERS_PROXY                  | The number of workers processing API Proxies, only in proxy mode                                | 10                                |
-| APIGEE_WORKERS_PRODUCT                | The number of workers processing Products, only in product mode                                 | 10                                |
-| APIGEE_WORKERS_SPEC                   | The number of workers processing API Specs                                                      | 20                                |
-| APIGEE_AUTH_USERNAME                  | The Apigee account username/email address                                                       |                                   |
-| APIGEE_AUTH_PASSWORD                  | The Apigee account password                                                                     |                                   |
-| APIGEE_AUTH_USEBASICAUTH              | Set this to true to have the Apigee api client use HTTP Basic Authentication                    | false                             |
-| APIGEE_AUTH_URL                       | The IDP URL                                                                                     | https://login.apigee.com          |
-| APIGEE_AUTH_SERVERUSERNAME            | The IDP username for requesting tokens                                                          | edgecli                           |
-| APIGEE_AUTH_SERVERPASSWORD            | The IDP password for requesting tokens                                                          | edgeclisecret                     |
-| APIGEE_SPECCONFIG_LOCALPATH           | Path to a local directory that contains the spec files                                          |                                   |
-| APIGEE_SPECCONFIG_EXTENSIONS          | Comma separated list of file extensions that the agent will look for spec in the local path for | json,yaml,yml                     |
-| APIGEE_SPECCONFIG_UNSTRUCTURED        | Set to true to enable discovering apis that have no associated spec                             | false                             |
-| APIGEE_SPECCONFIG_DISABLEPOLLFORSPECS | Set to true to disable polling apigee for specs, rely on the local directory or spec URLs       | false                             |
+| Environment Variable                  | Description                                                                                         | Default (if applicable)           |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------- |
+| APIGEE_URL                            | The base Apigee URL for this agent to connect to                                                    | https://api.enterprise.apigee.com |
+| APIGEE_APIVERSION                     | The version of the API for the agent to use                                                         | v1                                |
+| APIGEE_DATAURL                        | The base Apigee Data API URL for this agent to connect to                                           | https://apigee.com/dapi/api       |
+| APIGEE_ORGANIZATION                   | The Apigee organization name                                                                        |                                   |
+| APIGEE_DEVELOPERID                    | The Apigee developer, email, that will own all apps                                                 |                                   |
+| APIGEE_DISCOVERYMODE                  | The mode in which the agent operates, discover proxies (proxy) or products (product)                | proxy                             |
+| APIGEE_FILTER                         | The tag filter to use against an Apigee product's attributes, only in product mode                  |                                   |
+| APIGEE_CLONEATTRIBUTES                | Set this to true if the tags on a product should also be cloned on provisioning                     | false                             |
+| APIGEE_INTERVAL_PROXY                 | The polling interval checking for API Proxy changes, only in proxy mode                             | 30s (30 seconds), >=30s, <=5m     |
+| APIGEE_INTERVAL_PRODUCT               | The polling interval checking for Product changes, only in product mode                             | 30s (30 seconds), >=30s, <=5m     |
+| APIGEE_INTERVAL_SPEC                  | The polling interval for checking for new Specs                                                     | 30m (30 minute), >=1m             |
+| APIGEE_WORKERS_PROXY                  | The number of workers processing API Proxies, only in proxy mode                                    | 10                                |
+| APIGEE_WORKERS_PRODUCT                | The number of workers processing Products, only in product mode                                     | 10                                |
+| APIGEE_WORKERS_SPEC                   | The number of workers processing API Specs                                                          | 20                                |
+| APIGEE_AUTH_USERNAME                  | The Apigee account username/email address                                                           |                                   |
+| APIGEE_AUTH_PASSWORD                  | The Apigee account password                                                                         |                                   |
+| APIGEE_AUTH_USEBASICAUTH              | Set this to true to have the Apigee api client use HTTP Basic Authentication                        | false                             |
+| APIGEE_AUTH_URL                       | The IDP URL                                                                                         | https://login.apigee.com          |
+| APIGEE_AUTH_SERVERUSERNAME            | The IDP username for requesting tokens                                                              | edgecli                           |
+| APIGEE_AUTH_SERVERPASSWORD            | The IDP password for requesting tokens                                                              | edgeclisecret                     |
+| APIGEE_SPECCONFIG_MATCHONURL          | Set to false to skip parsing specs for URLs and matching to computed proxy url for spec association | true                              |
+| APIGEE_SPECCONFIG_LOCALPATH           | Path to a local directory that contains the spec files                                              |                                   |
+| APIGEE_SPECCONFIG_EXTENSIONS          | Comma separated list of file extensions that the agent will look for spec in the local path for     | json,yaml,yml                     |
+| APIGEE_SPECCONFIG_UNSTRUCTURED        | Set to true to enable discovering apis that have no associated spec                                 | false                             |
+| APIGEE_SPECCONFIG_DISABLEPOLLFORSPECS | Set to true to disable polling apigee for specs, rely on the local directory or spec URLs           | false                             |
 
 
 ## Development

--- a/discovery/pkg/apigee/pollproxiesjob.go
+++ b/discovery/pkg/apigee/pollproxiesjob.go
@@ -225,9 +225,7 @@ func (j *pollProxiesJob) handleRevision(ctx context.Context, revName string) {
 	logger := getLoggerFromContext(ctx).WithField(revNameField.String(), revName)
 	addLoggerToContext(ctx, logger)
 	logger.Debug("handling revision")
-	pName := getStringFromContext(ctx, proxyNameField)
 
-	_ = pName
 	revision, err := j.client.GetRevision(getStringFromContext(ctx, proxyNameField), revName)
 	if err != nil {
 		logger.WithError(err).Error("getting revision")

--- a/discovery/pkg/apigee/pollproxiesjob.go
+++ b/discovery/pkg/apigee/pollproxiesjob.go
@@ -397,12 +397,7 @@ func (j *pollProxiesJob) getSpecFromResourceFile(ctx context.Context, resourceTy
 		logger.WithError(err).Debug("could not read resource file content")
 	}
 
-	// get the association.json file content
-	_, err = j.cache.GetSpecWithPath(associationFile.URL)
-	if err != nil {
-		logger.WithError(err).Error("spec path not found in cache")
-		return ""
-	}
+	// return the association.json file content
 	return associationFile.URL
 }
 

--- a/discovery/pkg/apigee/pollproxiesjob.go
+++ b/discovery/pkg/apigee/pollproxiesjob.go
@@ -56,32 +56,30 @@ type proxyCache interface {
 // job that will poll for any new portals on APIGEE Edge
 type pollProxiesJob struct {
 	jobs.Job
-	client          proxyClient
-	firstRun        bool
-	cache           proxyCache
-	logger          log.FieldLogger
-	specsReady      jobFirstRunDone
-	pubLock         sync.Mutex
-	publishFunc     agent.PublishAPIFunc
-	workers         int
-	running         bool
-	runningLock     sync.Mutex
-	virtualHostURLs map[string]map[string][]string
-	lastTime        int
-	runTime         int
+	client      proxyClient
+	firstRun    bool
+	cache       proxyCache
+	logger      log.FieldLogger
+	specsReady  jobFirstRunDone
+	pubLock     sync.Mutex
+	publishFunc agent.PublishAPIFunc
+	workers     int
+	running     bool
+	runningLock sync.Mutex
+	lastTime    int
+	runTime     int
 }
 
 func newPollProxiesJob(client proxyClient, cache proxyCache, specsReady jobFirstRunDone, workers int) *pollProxiesJob {
 	job := &pollProxiesJob{
-		client:          client,
-		cache:           cache,
-		firstRun:        true,
-		specsReady:      specsReady,
-		logger:          log.NewFieldLogger().WithComponent("pollProxies").WithPackage("apigee"),
-		publishFunc:     agent.PublishAPI,
-		workers:         workers,
-		runningLock:     sync.Mutex{},
-		virtualHostURLs: make(map[string]map[string][]string),
+		client:      client,
+		cache:       cache,
+		firstRun:    true,
+		specsReady:  specsReady,
+		logger:      log.NewFieldLogger().WithComponent("pollProxies").WithPackage("apigee"),
+		publishFunc: agent.PublishAPI,
+		workers:     workers,
+		runningLock: sync.Mutex{},
 	}
 	return job
 }
@@ -301,20 +299,22 @@ func (j *pollProxiesJob) getVirtualHostURLs(ctx context.Context) context.Context
 		return context.WithValue(ctx, endpointsField, allURLs)
 	}
 
-	if _, ok := j.virtualHostURLs[envName]; !ok {
-		j.virtualHostURLs[envName] = make(map[string][]string)
+	virtualHostURLs := make(map[string]map[string][]string)
+
+	if _, ok := virtualHostURLs[envName]; !ok {
+		virtualHostURLs[envName] = make(map[string][]string)
 	}
 
-	if _, ok := j.virtualHostURLs[envName][connection.VirtualHost]; !ok {
+	if _, ok := virtualHostURLs[envName][connection.VirtualHost]; !ok {
 		virtualHost, err := j.client.GetVirtualHost(envName, connection.VirtualHost)
 		if err != nil {
 			logger.WithError(err).Error("could not get the virtual host info")
 			return context.WithValue(ctx, endpointsField, allURLs)
 		}
-		j.virtualHostURLs[envName][connection.VirtualHost] = urlsFromVirtualHost(virtualHost)
+		virtualHostURLs[envName][connection.VirtualHost] = urlsFromVirtualHost(virtualHost)
 	}
 
-	for _, url := range j.virtualHostURLs[envName][connection.VirtualHost] {
+	for _, url := range virtualHostURLs[envName][connection.VirtualHost] {
 		allURLs = append(allURLs, fmt.Sprintf("%s%s", url, connection.BasePath))
 	}
 

--- a/discovery/pkg/apigee/pollproxiesjob.go
+++ b/discovery/pkg/apigee/pollproxiesjob.go
@@ -322,7 +322,7 @@ func (j *pollProxiesJob) getVirtualHostURLs(ctx context.Context) context.Context
 	revision := ctx.Value(revNameField).(*models.ApiProxyRevision)
 	envName := getStringFromContext(ctx, envNameField)
 	proxyName := getStringFromContext(ctx, proxyNameField)
-	allURLs := []string{}
+	allURLs := getStringArrayFromContext(ctx, endpointsField)
 
 	connection, err := j.client.GetRevisionConnectionType(proxyName, revision.Revision)
 	if err != nil {

--- a/discovery/pkg/apigee/pollproxiesjob_test.go
+++ b/discovery/pkg/apigee/pollproxiesjob_test.go
@@ -101,7 +101,11 @@ func Test_pollProxiesJob(t *testing.T) {
 				hasAPIKey:        tc.hasAPIKey,
 				hasOauth:         tc.hasOauth,
 			}
-			proxyJob := newPollProxiesJob(client, mockProxyCache{pathSpec: tc.specPath, nameSpec: tc.specName}, func() bool { return true }, 10)
+			proxyJob := newPollProxiesJob().
+				SetSpecClient(client).
+				SetSpecCache(mockProxyCache{pathSpec: tc.specPath, nameSpec: tc.specName}).
+				SetSpecsReady(func() bool { return true }).
+				SetWorkers(10)
 			assert.False(t, proxyJob.FirstRunComplete())
 
 			// receive the publish call and validate what was published

--- a/discovery/pkg/apigee/pollspecsjob.go
+++ b/discovery/pkg/apigee/pollspecsjob.go
@@ -37,17 +37,33 @@ type pollSpecsJob struct {
 	runningLock sync.Mutex
 }
 
-func newPollSpecsJob(client specClient, cache specCache, workers int, parseSpec bool) *pollSpecsJob {
+func newPollSpecsJob() *pollSpecsJob {
 	job := &pollSpecsJob{
-		client:      client,
-		cache:       cache,
 		firstRun:    true,
 		logger:      log.NewFieldLogger().WithComponent("pollSpecs").WithPackage("apigee"),
-		workers:     workers,
 		runningLock: sync.Mutex{},
-		parseSpec:   parseSpec,
 	}
 	return job
+}
+
+func (j *pollSpecsJob) SetSpecClient(client specClient) *pollSpecsJob {
+	j.client = client
+	return j
+}
+
+func (j *pollSpecsJob) SetSpecCache(cache specCache) *pollSpecsJob {
+	j.cache = cache
+	return j
+}
+
+func (j *pollSpecsJob) SetWorkers(workers int) *pollSpecsJob {
+	j.workers = workers
+	return j
+}
+
+func (j *pollSpecsJob) SetParseSpec(parseSpec bool) *pollSpecsJob {
+	j.parseSpec = parseSpec
+	return j
 }
 
 func (j *pollSpecsJob) Ready() bool {

--- a/discovery/pkg/apigee/util.go
+++ b/discovery/pkg/apigee/util.go
@@ -79,6 +79,14 @@ func getStringFromContext(ctx context.Context, key ctxKeys) string {
 	return ctx.Value(key).(string)
 }
 
+func getStringArrayFromContext(ctx context.Context, key ctxKeys) []string {
+	v := ctx.Value(key)
+	if v != nil {
+		return v.([]string)
+	}
+	return []string{}
+}
+
 func createEndpointsFromURLS(urls []string) []apic.EndpointDefinition {
 	endpoints := []apic.EndpointDefinition{}
 


### PR DESCRIPTION
- if openapi/association.json exists on revision use its url, do not require match in cache 
- allow turning off url match, less over head to parse spec files
- if association.json does not exist attempt to match spec in spec repo by name ([ISSUE-190](https://github.com/Axway/agents-apigee/issues/190))
- remove use of struct map to avoid concurrent map writes