### PR TITLE
APIGOV-30409 - TA poll interval updates

### DIFF
--- a/client/pkg/config/config.go
+++ b/client/pkg/config/config.go
@@ -158,7 +158,7 @@ func AddProperties(rootProps props) {
 	rootProps.AddDurationProperty(pathSpecInterval, 30*time.Minute, "The time interval between checking for updated specs", properties.WithLowerLimit(1*time.Minute))
 	rootProps.AddDurationProperty(pathProxyInterval, 30*time.Second, "The time interval between checking for updated proxies", properties.WithUpperLimit(5*time.Minute))
 	rootProps.AddDurationProperty(pathProductInterval, 30*time.Second, "The time interval between checking for updated products", properties.WithUpperLimit(5*time.Minute))
-	rootProps.AddDurationProperty(pathStatsInterval, 15*time.Minute, "The time interval between checking for updated stats", properties.WithLowerLimit(15*time.Minute))
+	rootProps.AddDurationProperty(pathStatsInterval, 5*time.Minute, "The time interval between checking for updated stats", properties.WithLowerLimit(15*time.Minute))
 	rootProps.AddStringProperty(pathDeveloper, "", "Developer ID used to create applications")
 	rootProps.AddIntProperty(pathProxyWorkers, 10, "Max number of workers discovering proxies")
 	rootProps.AddIntProperty(pathSpecWorkers, 20, "Max number of workers discovering specs")

--- a/client/pkg/config/config.go
+++ b/client/pkg/config/config.go
@@ -158,7 +158,7 @@ func AddProperties(rootProps props) {
 	rootProps.AddDurationProperty(pathSpecInterval, 30*time.Minute, "The time interval between checking for updated specs", properties.WithLowerLimit(1*time.Minute))
 	rootProps.AddDurationProperty(pathProxyInterval, 30*time.Second, "The time interval between checking for updated proxies", properties.WithUpperLimit(5*time.Minute))
 	rootProps.AddDurationProperty(pathProductInterval, 30*time.Second, "The time interval between checking for updated products", properties.WithUpperLimit(5*time.Minute))
-	rootProps.AddDurationProperty(pathStatsInterval, 5*time.Minute, "The time interval between checking for updated stats", properties.WithLowerLimit(15*time.Minute))
+	rootProps.AddDurationProperty(pathStatsInterval, 5*time.Minute, "The time interval between checking for updated stats", properties.WithLowerLimit(30*time.Second))
 	rootProps.AddStringProperty(pathDeveloper, "", "Developer ID used to create applications")
 	rootProps.AddIntProperty(pathProxyWorkers, 10, "Max number of workers discovering proxies")
 	rootProps.AddIntProperty(pathSpecWorkers, 20, "Max number of workers discovering specs")

--- a/client/pkg/config/config_test.go
+++ b/client/pkg/config/config_test.go
@@ -165,7 +165,7 @@ func TestApigeeProperties(t *testing.T) {
 	assert.Equal(t, 30*time.Minute, cfg.GetIntervals().Spec)
 	assert.Equal(t, 30*time.Second, cfg.GetIntervals().Proxy)
 	assert.Equal(t, 30*time.Second, cfg.GetIntervals().Product)
-	assert.Equal(t, 15*time.Minute, cfg.GetIntervals().Stats)
+	assert.Equal(t, 5*time.Minute, cfg.GetIntervals().Stats)
 	assert.Equal(t, "", cfg.DeveloperID)
 	assert.Equal(t, 10, cfg.GetWorkers().Proxy)
 	assert.Equal(t, 20, cfg.GetWorkers().Spec)

--- a/traceability/apigee_traceability_agent.yml
+++ b/traceability/apigee_traceability_agent.yml
@@ -11,7 +11,7 @@ apigee_traceability_agent:
     filteredAPIs: ${APIGEE_FILTERED_APIS}
     filterMetrics: ${APIGEE_FILTER_METRICS:true}
     interval:
-      stats: ${APIGEE_INTERVAL_STATS:15m}
+      stats: ${APIGEE_INTERVAL_STATS:5m}
     auth:
       username: ${APIGEE_AUTH_USERNAME}
       password: ${APIGEE_AUTH_PASSWORD}


### PR DESCRIPTION
uses 5 min TA default polling   interval and 30 seconds as minimum